### PR TITLE
Add setup instructions and expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # gardener
+
+This project automates watering of our plants using a PyBoard and a set of
+small pumps. The initial goal is to reliably keep a few houseplants happy, but
+the framework is flexible enough to grow into other automation tasks as well.
+
+The core code lives in the `waterer` directory and is meant to run under
+MicroPython on the board.

--- a/waterer/README.md
+++ b/waterer/README.md
@@ -1,0 +1,12 @@
+# Waterer Hardware Setup
+
+This module runs on a PyBoard controlling a handful of small DC pumps. Below is a minimal wiring guide:
+
+1. Use a MOSFET or driver board for each pump and connect its gate to the pins
+   defined in `config.py`.
+2. Wire the pumps' positive terminals to the driver outputs and tie all grounds
+   together with the PyBoard ground.
+3. Provide an appropriate power supply for the pumps (often 5V) separate from
+   the PyBoard's USB power.
+4. Copy the files in this directory onto the PyBoard and run `main.py` to start
+   the daily watering schedule.


### PR DESCRIPTION
## Summary
- expand root README with project overview
- document hardware instructions in `waterer/README.md`

## Testing
- `python -m py_compile waterer/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6869db130b448323806f8361a35873b6